### PR TITLE
Issue #15 Fix: The example of the atom orbital is WRONG and failed to compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.2
+### Fixes
+* Fixed P Orbital example. Special thanks to [@Roseleaves](https://github.com/Roseleaves) for opening the [related issue #15](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/15). [7ffdc5](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/16/commits/7ffdc52f90bae0605c27a3f9d545d0538a51c04b). 
+
+## 0.3.1
+### Bugfixes
+* Fixed animation issue with SimpleLine and its subclasses.
+
 ## 0.3.0
 ### New Features
 * Added GenericElement class that will be the base for future developments. [1668d67](https://github.com/UnMolDeQuimica/manim-Chemistry/commit/1668d670752c86b860ff20c2d9e58ba4286329e1)

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -1,4 +1,4 @@
-from manim import Scene, ThreeDScene
+from manim import Scene, ThreeDScene, config
 from manim_chemistry import (
     MMoleculeObject,
     GraphMolecule,
@@ -16,22 +16,30 @@ files_path = script_path / "element_files"
 
 # 2D Molecule example
 class Draw2DMorphine(Scene):
+    # Two D Manim Chemistry objects require Cairo renderer
+    config.renderer = "cairo"
     def construct(self):    
         morphine = MMoleculeObject.from_mol_file(filename=files_path / "morphine.mol")
         self.add(morphine)
 
 # 2D Graph Molecule example
 class DrawGraphMorphine(Scene):
+    # Two D Manim Chemistry objects require Cairo renderer
+    config.renderer = "cairo"
     def construct(self):
-        self.add(GraphMolecule.build_from_mol(filename=files_path / "morphine.mol"))
+        self.add(GraphMolecule.build_from_mol(mol_file=files_path / "morphine.mol"))
         
 # 2D Graph Molecule example
 class DrawLabeledGraphMorphine(Scene):
+    # Two D Manim Chemistry objects require Cairo renderer
+    config.renderer = "cairo"
     def construct(self):
-        self.add(GraphMolecule.build_from_mol(filename=files_path / "morphine.mol"))
+        self.add(GraphMolecule.build_from_mol(mol_file=files_path / "morphine.mol", label=True))
         
 # 3D Molecule example
 class Draw3DMorphine(ThreeDScene):
+    # Three D Manim Chemistry objects require opengl renderer
+    config.renderer = "opengl"
     def construct(self):
         self.add(ThreeDMolecule.from_mol_file(filename=files_path / "morphine3d.mol", source_csv=files_path / "Elementos.csv"))
         self.wait()
@@ -39,6 +47,8 @@ class Draw3DMorphine(ThreeDScene):
 
 # Element example
 class DrawCarbonElement(Scene):
+    # Two D Manim Chemistry objects require Cairo renderer
+    config.renderer = "cairo"
     def construct(self):
         self.add(
             MElementObject.from_csv_file_data(
@@ -49,17 +59,23 @@ class DrawCarbonElement(Scene):
 
 # Periodic Table example
 class DrawPeriodicTable(Scene):
+    # Two D Manim Chemistry objects require Cairo renderer
+    config.renderer = "cairo"
     def construct(self):
         self.add(PeriodicTable(data_file=files_path / "Elementos.csv"))
 
 
 # Orbitals example 
-class DrawPOrbital(Scene):
+class DrawPOrbital(ThreeDScene):
+    # Three D Manim Chemistry objects require opengl renderer
+    config.renderer = "opengl"
     def construct(self):
         self.add(Orbital(l=1, m=-1))
 
 
 # Bohr diagram example
 class BohrDiagram(Scene):
+    # Two D Manim Chemistry objects require Cairo renderer
+    config.renderer = "cairo"
     def construct(self):
         self.add(BohrAtom())

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -14,6 +14,7 @@ from pathlib import Path
 script_path = Path(__file__).absolute().parent
 files_path = script_path / "element_files"
 
+
 # 2D Molecule example
 class Draw2DMorphine(Scene):
     # Two D Manim Chemistry objects require Cairo renderer
@@ -22,13 +23,15 @@ class Draw2DMorphine(Scene):
         morphine = MMoleculeObject.from_mol_file(filename=files_path / "morphine.mol")
         self.add(morphine)
 
+
 # 2D Graph Molecule example
 class DrawGraphMorphine(Scene):
     # Two D Manim Chemistry objects require Cairo renderer
     config.renderer = "cairo"
     def construct(self):
         self.add(GraphMolecule.build_from_mol(mol_file=files_path / "morphine.mol"))
-        
+    
+    
 # 2D Graph Molecule example
 class DrawLabeledGraphMorphine(Scene):
     # Two D Manim Chemistry objects require Cairo renderer
@@ -36,9 +39,10 @@ class DrawLabeledGraphMorphine(Scene):
     def construct(self):
         self.add(GraphMolecule.build_from_mol(mol_file=files_path / "morphine.mol", label=True))
         
+        
 # 3D Molecule example
 class Draw3DMorphine(ThreeDScene):
-    # Three D Manim Chemistry objects require opengl renderer
+    # Three D Manim Chemistry objects require Opengl renderer
     config.renderer = "opengl"
     def construct(self):
         self.add(ThreeDMolecule.from_mol_file(filename=files_path / "morphine3d.mol", source_csv=files_path / "Elementos.csv"))
@@ -67,7 +71,7 @@ class DrawPeriodicTable(Scene):
 
 # Orbitals example 
 class DrawPOrbital(ThreeDScene):
-    # Three D Manim Chemistry objects require opengl renderer
+    # Three D Manim Chemistry objects require Opengl renderer
     config.renderer = "opengl"
     def construct(self):
         self.add(Orbital(l=1, m=-1))


### PR DESCRIPTION
The example `Orbitals example`  was returning an error because the class was `Scene` instead of `ThreeDScene` and also the renderer was not specified in the example. It should be `opengl` for all three d manim-chemistry objects. 