### PR TITLE
46 Modify automated tests to work only on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,37 +1,35 @@
-# name: Integration tests
+name: Integration tests
 
-# on:
-#   push:
-#   pull_request:
+on: [pull_ request]
 
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# jobs:
-#   pytest:
-#     name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+jobs:
+  pytest:
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
 
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         os:
-#           - macOS
-#           - Ubuntu
-#           - Windows
-#         python-version: ['3.8', '3.9', '3.10', '3.11']
-#     runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macOS
+          - Ubuntu
+          - Windows
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    runs-on: ${{ matrix.os }}-latest
 
-#     steps:
-#     - uses: actions/checkout@v2
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Install dependencies
-#       run: |
-#         python -m pip install --upgrade pip
-#         python -m pip install .
-#     - name: Test with pytest
-#       run: |
-#         python -m pytest ./tests/
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+    - name: Test with pytest
+      run: |
+        python -m pytest ./tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Integration tests
 
-on: [pull_ request]
+on: [pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Current test system runs the tests on every push of a branch. 

This PR modifies it so they only run on Pull Requests, avoiding having a ton of unnecessary emails on my inbox.

Associated issue: https://github.com/UnMolDeQuimica/manim-Chemistry/issues/46