### PR TITLE
68 add ignore hydrogens function

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,7 @@ _Write here the description of your PR_
 
 # Related issue
 
-_Leave here the link to the related issue in the following format_
-
-`[#<Issue number> <Issue title>](Issue link)`
+[#<Issue number> <Issue title>](Issue link)
 
 # Pre merge checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [Issue #45](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/63): Adds `molecule_from_string` and `multiple_molecules_from_string` to GraphMolecule, ThreeDMolecule and MMolecule.
 * [Issue #45](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/63): Adds support for Pub Chem API.
 * [Issue #45](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/63): Use of source csv is now optional on ThreeDMolecules.
+* [Issue #68](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/72): Added `ignore_hydrogens` and `ignore_all_hydrogens` parameter to MCMolecule molecule generation functions.
 
 ### Improvements
 * [Issue #46](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/47): Modify automated tests to work only on pull requests.

--- a/src/manim_chemistry/manim_chemistry_molecule/mc_molecule.py
+++ b/src/manim_chemistry/manim_chemistry_molecule/mc_molecule.py
@@ -83,7 +83,12 @@ class MCMolecule:
             mc_bond.to_atom.add_bonds(mc_bond)
 
     @staticmethod
-    def construct_from_data_dict(atoms_data_dict: dict, bonds_data_dict: dict, ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False):
+    def construct_from_data_dict(
+        atoms_data_dict: dict,
+        bonds_data_dict: dict,
+        ignore_hydrogens: bool = True,
+        ignore_all_hydrogens: bool = False,
+    ):
         """
         Given data with the format provided by a parser, constructs a MCMolecule,
         the corresponding MCAtoms and MCBonds and stablishes the connections between
@@ -108,7 +113,9 @@ class MCMolecule:
         return mc_molecule
 
     @staticmethod
-    def construct_from_file(filepath, ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False):
+    def construct_from_file(
+        filepath, ignore_hydrogens: bool = True, ignore_all_hydrogens: bool = False
+    ):
         """
         Returns an MCMolecule given a file path.
 
@@ -121,10 +128,17 @@ class MCMolecule:
             parsed_data = parsed_data[0]
 
         atoms_dict, bonds_dict = parsed_data
-        return MCMolecule.construct_from_data_dict(atoms_dict, bonds_dict, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
+        return MCMolecule.construct_from_data_dict(
+            atoms_dict,
+            bonds_dict,
+            ignore_hydrogens=ignore_hydrogens,
+            ignore_all_hydrogens=ignore_all_hydrogens,
+        )
 
     @staticmethod
-    def construct_multiples_from_file(filepath, ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False):
+    def construct_multiples_from_file(
+        filepath, ignore_hydrogens: bool = True, ignore_all_hydrogens: bool = False
+    ):
         """
         Similar to `construct_from_file` but returning a list of MCMolecules.
         """
@@ -134,14 +148,22 @@ class MCMolecule:
         for atoms_dict, bonds_dict in list_of_data_dicts:
             mc_molecules.append(
                 MCMolecule.construct_from_data_dict(
-                    atoms_data_dict=atoms_dict, bonds_data_dict=bonds_dict, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens
+                    atoms_data_dict=atoms_dict,
+                    bonds_data_dict=bonds_dict,
+                    ignore_hydrogens=ignore_hydrogens,
+                    ignore_all_hydrogens=ignore_all_hydrogens,
                 )
             )
 
         return mc_molecules
 
     @staticmethod
-    def construct_from_string(string: str, format: str = "json", ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False):
+    def construct_from_string(
+        string: str,
+        format: str = "json",
+        ignore_hydrogens: bool = True,
+        ignore_all_hydrogens: bool = False,
+    ):
         """
         Reads a string and returns a molecule. Supported formats are:
         - mol
@@ -159,10 +181,20 @@ class MCMolecule:
 
         atoms_dict, bonds_dict = parsed_data
 
-        return MCMolecule.construct_from_data_dict(atoms_dict, bonds_dict, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
+        return MCMolecule.construct_from_data_dict(
+            atoms_dict,
+            bonds_dict,
+            ignore_hydrogens=ignore_hydrogens,
+            ignore_all_hydrogens=ignore_all_hydrogens,
+        )
 
     @staticmethod
-    def construct_multiples_from_string(string: str, format: str = "json", ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False):
+    def construct_multiples_from_string(
+        string: str,
+        format: str = "json",
+        ignore_hydrogens: bool = True,
+        ignore_all_hydrogens: bool = False,
+    ):
         """
         Similar to `construct_from_string` but returning a list of MCMolecules.
         """
@@ -171,7 +203,10 @@ class MCMolecule:
         for atoms_dict, bonds_dict in parsed_data:
             mc_molecules.append(
                 MCMolecule.construct_from_data_dict(
-                    atoms_data_dict=atoms_dict, bonds_data_dict=bonds_dict, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens
+                    atoms_data_dict=atoms_dict,
+                    bonds_data_dict=bonds_dict,
+                    ignore_hydrogens=ignore_hydrogens,
+                    ignore_all_hydrogens=ignore_all_hydrogens,
                 )
             )
 
@@ -183,7 +218,10 @@ class MCMolecule:
             if atom.element.atomic_number != 1:
                 continue
 
-            if atom.bonds[0].to_atom.element.atomic_number == 6 or atom.bonds[0].from_atom.element.atomic_number == 6:
+            if (
+                atom.bonds[0].to_atom.element.atomic_number == 6
+                or atom.bonds[0].from_atom.element.atomic_number == 6
+            ):
                 atoms_to_be_removed.append(index)
 
         return self.remove_hydrogens(atoms_to_be_removed)
@@ -234,7 +272,11 @@ class MCMolecule:
 
         for bond in self.bonds:
             if bond.from_atom.molecule_index in atoms_old_index_mapping.keys():
-                bond.from_atom.molecule_index = atoms_old_index_mapping[bond.from_atom.molecule_index]
+                bond.from_atom.molecule_index = atoms_old_index_mapping[
+                    bond.from_atom.molecule_index
+                ]
 
             if bond.to_atom.molecule_index in atoms_old_index_mapping.keys():
-                bond.to_atom.molecule_index = atoms_old_index_mapping[bond.to_atom.molecule_index]
+                bond.to_atom.molecule_index = atoms_old_index_mapping[
+                    bond.to_atom.molecule_index
+                ]

--- a/src/manim_chemistry/molecule/abstract_molecule.py
+++ b/src/manim_chemistry/molecule/abstract_molecule.py
@@ -22,7 +22,14 @@ class AbstractMolecule:
         ...
 
     @classmethod
-    def molecule_from_file(cls, filepath, ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs):
+    def molecule_from_file(
+        cls,
+        filepath,
+        ignore_hydrogens: bool = True,
+        ignore_all_hydrogens: bool = False,
+        *args,
+        **kwargs,
+    ):
         """
         Reads a file and returns a single molecule from that file.
 
@@ -34,18 +41,25 @@ class AbstractMolecule:
         Returns:
             GraphMolecule: GraphMolecule from the file
         """
-        mc_molecule = MCMolecule.construct_from_file(filepath=filepath, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
+        mc_molecule = MCMolecule.construct_from_file(
+            filepath=filepath,
+            ignore_hydrogens=ignore_hydrogens,
+            ignore_all_hydrogens=ignore_all_hydrogens,
+        )
         if isinstance(mc_molecule, list):
             mc_molecule = mc_molecule[0]
 
-        vertices, edges = cls.mc_molecule_to_atoms_and_bonds(
-            mc_molecule=mc_molecule
-        )
+        vertices, edges = cls.mc_molecule_to_atoms_and_bonds(mc_molecule=mc_molecule)
         return cls(vertices, edges, *args, **kwargs)
 
     @classmethod
     def multiple_molecules_from_file(
-        cls, filepath, ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs
+        cls,
+        filepath,
+        ignore_hydrogens: bool = True,
+        ignore_all_hydrogens: bool = False,
+        *args,
+        **kwargs,
     ) -> Union[OpenGLGroup, VGroup]:
         """
         Reads a file and returns a collection of molecules from that file as a OpenGLGroup or VGroup.
@@ -59,22 +73,32 @@ class AbstractMolecule:
         Returns:
             OpenGLGroup: OpenGLGroup with the molecules inside.
         """
-        mc_molecules = MCMolecule.construct_multiples_from_file(filepath=filepath, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
+        mc_molecules = MCMolecule.construct_multiples_from_file(
+            filepath=filepath,
+            ignore_hydrogens=ignore_hydrogens,
+            ignore_all_hydrogens=ignore_all_hydrogens,
+        )
 
         if not isinstance(mc_molecules, list):
             raise Exception(f"Expected a list of molecules. Received {mc_molecules}")
 
         mmolecules = cls.group_class()
         for mc_molecule in mc_molecules:
-            atoms, bonds = cls.mc_molecule_to_atoms_and_bonds(
-                mc_molecule=mc_molecule
-            )
+            atoms, bonds = cls.mc_molecule_to_atoms_and_bonds(mc_molecule=mc_molecule)
             mmolecules.add(cls(atoms, bonds, *args, **kwargs))
 
         return mmolecules
 
     @classmethod
-    def molecule_from_string(cls, string: str, format: str = "json", ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs):
+    def molecule_from_string(
+        cls,
+        string: str,
+        format: str = "json",
+        ignore_hydrogens: bool = True,
+        ignore_all_hydrogens: bool = False,
+        *args,
+        **kwargs,
+    ):
         """
         Reads a file and returns a single molecule from that file.
 
@@ -88,7 +112,12 @@ class AbstractMolecule:
             ThreeDMolecule: ThreeDMolecule from the string
         """
 
-        mc_molecule = MCMolecule.construct_from_string(string=string, format=format, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
+        mc_molecule = MCMolecule.construct_from_string(
+            string=string,
+            format=format,
+            ignore_hydrogens=ignore_hydrogens,
+            ignore_all_hydrogens=ignore_all_hydrogens,
+        )
         if isinstance(mc_molecule, list):
             mc_molecule = mc_molecule[0]
 
@@ -97,7 +126,13 @@ class AbstractMolecule:
 
     @classmethod
     def multiple_molecules_from_string(
-        cls, string: str, format: str = "json", ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs
+        cls,
+        string: str,
+        format: str = "json",
+        ignore_hydrogens: bool = True,
+        ignore_all_hydrogens: bool = False,
+        *args,
+        **kwargs,
     ) -> OpenGLGroup:
         """
         Reads a file and returns a collection of molecules from that file as a OpenGLGroup.
@@ -114,7 +149,10 @@ class AbstractMolecule:
         """
 
         mc_molecules = MCMolecule.construct_multiples_from_string(
-            string=string, format=format, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens
+            string=string,
+            format=format,
+            ignore_hydrogens=ignore_hydrogens,
+            ignore_all_hydrogens=ignore_all_hydrogens,
         )
 
         if not isinstance(mc_molecules, list):

--- a/src/manim_chemistry/molecule/abstract_molecule.py
+++ b/src/manim_chemistry/molecule/abstract_molecule.py
@@ -22,7 +22,7 @@ class AbstractMolecule:
         ...
 
     @classmethod
-    def molecule_from_file(cls, filepath, *args, **kwargs):
+    def molecule_from_file(cls, filepath, ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs):
         """
         Reads a file and returns a single molecule from that file.
 
@@ -34,7 +34,7 @@ class AbstractMolecule:
         Returns:
             GraphMolecule: GraphMolecule from the file
         """
-        mc_molecule = MCMolecule.construct_from_file(filepath=filepath)
+        mc_molecule = MCMolecule.construct_from_file(filepath=filepath, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
         if isinstance(mc_molecule, list):
             mc_molecule = mc_molecule[0]
 
@@ -45,7 +45,7 @@ class AbstractMolecule:
 
     @classmethod
     def multiple_molecules_from_file(
-        cls, filepath, *args, **kwargs
+        cls, filepath, ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs
     ) -> Union[OpenGLGroup, VGroup]:
         """
         Reads a file and returns a collection of molecules from that file as a OpenGLGroup or VGroup.
@@ -59,7 +59,7 @@ class AbstractMolecule:
         Returns:
             OpenGLGroup: OpenGLGroup with the molecules inside.
         """
-        mc_molecules = MCMolecule.construct_multiples_from_file(filepath=filepath)
+        mc_molecules = MCMolecule.construct_multiples_from_file(filepath=filepath, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
 
         if not isinstance(mc_molecules, list):
             raise Exception(f"Expected a list of molecules. Received {mc_molecules}")
@@ -74,7 +74,7 @@ class AbstractMolecule:
         return mmolecules
 
     @classmethod
-    def molecule_from_string(cls, string: str, format: str = "json", *args, **kwargs):
+    def molecule_from_string(cls, string: str, format: str = "json", ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs):
         """
         Reads a file and returns a single molecule from that file.
 
@@ -88,7 +88,7 @@ class AbstractMolecule:
             ThreeDMolecule: ThreeDMolecule from the string
         """
 
-        mc_molecule = MCMolecule.construct_from_string(string=string, format=format)
+        mc_molecule = MCMolecule.construct_from_string(string=string, format=format, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens)
         if isinstance(mc_molecule, list):
             mc_molecule = mc_molecule[0]
 
@@ -97,7 +97,7 @@ class AbstractMolecule:
 
     @classmethod
     def multiple_molecules_from_string(
-        cls, string: str, format: str = "json", *args, **kwargs
+        cls, string: str, format: str = "json", ignore_hydrogens: bool=True, ignore_all_hydrogens: bool=False, *args, **kwargs
     ) -> OpenGLGroup:
         """
         Reads a file and returns a collection of molecules from that file as a OpenGLGroup.
@@ -114,7 +114,7 @@ class AbstractMolecule:
         """
 
         mc_molecules = MCMolecule.construct_multiples_from_string(
-            string=string, format=format
+            string=string, format=format, ignore_hydrogens=ignore_hydrogens, ignore_all_hydrogens=ignore_all_hydrogens
         )
 
         if not isinstance(mc_molecules, list):


### PR DESCRIPTION
# Description

Adds `ignore_hydrogens` and `ignore_all_hydrogens` function. This allows us to do not include hydrogen atoms on a molecule by simply modifying a parameter.

# Related issue

[#68 Add ignore hydrogens function on GraphMolecule](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/68)

# Pre merge checks

Check the corresponding boxes:

## Tests
*New tests are needed*

- [X] All tests pass.
- [ ] New tests were added.
- [ ] New tests were not needed because they are not needed.
- [ ] New tests were not added because I need help.

## Documentation
- [ ] Documentation is up to date with the latest changes.
- [ ] New documentation was not added because it is not needed.
- [ ] New documentation was not added because I need help.

## Linting
- [X] Ruff check passes.
- X ] Ruff format used.

## Changelog
- [X] Changelog has been updated
