### PR TITLE
75 Add support for 3D structures on PubChem API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [Issue #45](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/63): Adds support for Pub Chem API.
 * [Issue #45](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/63): Use of source csv is now optional on ThreeDMolecules.
 * [Issue #68](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/72): Added `ignore_hydrogens` and `ignore_all_hydrogens` parameter to MCMolecule molecule generation functions.
+* [Issue #75](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/76): Adds support for 3D structures on Pub Chem API.
 
 ### Improvements
 * [Issue #46](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/47): Modify automated tests to work only on pull requests.

--- a/src/manim_chemistry/molecule/abstract_molecule.py
+++ b/src/manim_chemistry/molecule/abstract_molecule.py
@@ -172,6 +172,7 @@ class AbstractMolecule:
         name: Optional[str] = None,
         smiles: Optional[str] = None,
         inchi: Optional[str] = None,
+        three_d: bool=False,
         *args,
         **kwargs,
     ):
@@ -188,7 +189,7 @@ class AbstractMolecule:
             GraphMolecule: GraphMolecule
         """
         pubchem_api_manager = PubchemAPIManager(
-            cid=cid, name=name, smiles=smiles, inchi=inchi
+            cid=cid, name=name, smiles=smiles, inchi=inchi, three_d=three_d
         )
 
         return cls.molecule_from_string(

--- a/src/manim_chemistry/molecule/abstract_molecule.py
+++ b/src/manim_chemistry/molecule/abstract_molecule.py
@@ -172,7 +172,7 @@ class AbstractMolecule:
         name: Optional[str] = None,
         smiles: Optional[str] = None,
         inchi: Optional[str] = None,
-        three_d: bool=False,
+        three_d: bool = False,
         *args,
         **kwargs,
     ):

--- a/src/manim_chemistry/utils/pubchem_api.py
+++ b/src/manim_chemistry/utils/pubchem_api.py
@@ -13,16 +13,17 @@ class PubchemAPIManager:
         name: Optional[str] = None,
         smiles: Optional[str] = None,
         inchi: Optional[str] = None,
+        three_d: bool=False,
     ):
         if not any([cid, name, smiles, inchi]):
             raise Exception(
                 "You should provide an identifier. Available identifiers are cid, name, smiles and inchi"
             )
-
         self.cid = cid
         self.name = name
         self.smiles = smiles
         self.inchi = inchi
+        self.three_d = three_d
 
     def handle_request(self, request: requests.models.Response, identifier):
         if request.status_code == 200:
@@ -36,23 +37,35 @@ class PubchemAPIManager:
         )
 
     def from_cid(self):
-        request = requests.get(f"{PubchemAPIManager.BASE_URL}/cid/{self.cid}/json")
+        request_url = f"{PubchemAPIManager.BASE_URL}/cid/{self.cid}/json"
+        if self.three_d:
+            request_url += "?record_type=3d"
+
+        request = requests.get(request_url)
         return self.handle_request(request=request, identifier=self.cid)
 
     def from_name(self):
-        request = requests.get(f"{PubchemAPIManager.BASE_URL}/name/{self.name}/json")
+        request_url = f"{PubchemAPIManager.BASE_URL}/name/{self.name}/json"
+        if self.three_d:
+            request_url += "?record_type=3d"
+
+        request = requests.get(request_url)
         return self.handle_request(request=request, identifier=self.name)
 
     def from_smiles(self):
-        request = requests.get(
-            f"{PubchemAPIManager.BASE_URL}/smiles/{self.smiles}/json"
-        )
+        request_url = f"{PubchemAPIManager.BASE_URL}/smiles/{self.smiles}/json"
+        if self.three_d:
+            request_url += "?record_type=3d"
+
+        request = requests.get(request_url)
         return self.handle_request(request=request, identifier=self.smiles)
 
     def from_inchi(self):
-        request = requests.get(
-            f"{PubchemAPIManager.BASE_URL}/inchikey/{self.inchi}/json"
-        )
+        request_url = f"{PubchemAPIManager.BASE_URL}/inchikey/{self.inchi}/json"
+        if self.three_d:
+            request_url += "?record_type=3d"
+
+        request = requests.get(request_url)
         return self.handle_request(request=request, identifier=self.inchi)
 
     def get_molecule(self):

--- a/src/manim_chemistry/utils/pubchem_api.py
+++ b/src/manim_chemistry/utils/pubchem_api.py
@@ -13,7 +13,7 @@ class PubchemAPIManager:
         name: Optional[str] = None,
         smiles: Optional[str] = None,
         inchi: Optional[str] = None,
-        three_d: bool=False,
+        three_d: bool = False,
     ):
         if not any([cid, name, smiles, inchi]):
             raise Exception(

--- a/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
+++ b/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
@@ -71,7 +71,9 @@ class TestGraphMolecule(BaseTestMolecule):
         assert isinstance(molecule, self.molecule_class)
 
     def test_from_pubchem_api_name_three_d(self):
-        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin", three_d=True)
+        molecule = self.molecule_class.molecule_from_pubchem(
+            name="aspirin", three_d=True
+        )
         assert isinstance(molecule, self.molecule_class)
 
     def test_from_pubchem_api_smiles_three_d(self):

--- a/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
+++ b/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
@@ -65,3 +65,23 @@ class TestGraphMolecule(BaseTestMolecule):
             inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
         )
         assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_cid_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244", three_d=True)
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_name_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin", three_d=True)
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_smiles_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O", three_d=True
+        )
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_inchi_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
+        )
+        assert isinstance(molecule, self.molecule_class)

--- a/tests/test_molecules/test_mmolecule/test_three_d_molecule.py
+++ b/tests/test_molecules/test_mmolecule/test_three_d_molecule.py
@@ -32,3 +32,23 @@ class TestThreeDMolecule(BaseTestMolecule):
             inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
         )
         assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_cid_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244", three_d=True)
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_name_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin", three_d=True)
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_smiles_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O", three_d=True
+        )
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_inchi_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
+        )
+        assert isinstance(molecule, self.molecule_class)

--- a/tests/test_molecules/test_mmolecule/test_three_d_molecule.py
+++ b/tests/test_molecules/test_mmolecule/test_three_d_molecule.py
@@ -38,7 +38,9 @@ class TestThreeDMolecule(BaseTestMolecule):
         assert isinstance(molecule, self.molecule_class)
 
     def test_from_pubchem_api_name_three_d(self):
-        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin", three_d=True)
+        molecule = self.molecule_class.molecule_from_pubchem(
+            name="aspirin", three_d=True
+        )
         assert isinstance(molecule, self.molecule_class)
 
     def test_from_pubchem_api_smiles_three_d(self):

--- a/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
+++ b/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
@@ -32,3 +32,23 @@ class TestThreeDMolecule(BaseTestMolecule):
             inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
         )
         assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_cid_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244", three_d=True)
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_name_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin", three_d=True)
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_smiles_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O", three_d=True
+        )
+        assert isinstance(molecule, self.molecule_class)
+
+    def test_from_pubchem_api_inchi_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
+        )
+        assert isinstance(molecule, self.molecule_class)

--- a/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
+++ b/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
@@ -38,7 +38,9 @@ class TestThreeDMolecule(BaseTestMolecule):
         assert isinstance(molecule, self.molecule_class)
 
     def test_from_pubchem_api_name_three_d(self):
-        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin", three_d=True)
+        molecule = self.molecule_class.molecule_from_pubchem(
+            name="aspirin", three_d=True
+        )
         assert isinstance(molecule, self.molecule_class)
 
     def test_from_pubchem_api_smiles_three_d(self):


### PR DESCRIPTION
# Description

Adds support for 3D structures from the PubChem API

# Related issue

[#75 Add support for 3D structures on PubChem API](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/75)

# Pre merge checks

Check the corresponding boxes:

## Tests

- [X] All tests pass.
- [X] New tests were added.
- [ ] New tests were not needed because they are not needed.
- [ ] New tests were not added because I need help.

## Documentation
- [ ] Documentation is up to date with the latest changes.
- [ ] New documentation was not added because it is not needed.
- [ ] New documentation was not added because I need help.

## Linting
- [X] Ruff check passes.
- [X] Ruff format used.

## Changelog
- [X] Changelog has been updated
