### PR TITLE
74 Add error message when using ThreeDMolecule without OpenGL renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [Issue #59](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/59): Modifies MMolecule to use parsers.
 * [Issue #70](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/71): Implements AbstractMolecule across all molecule types.
 * [Issue #66](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/71): Adds tests for the new changes.
+* [Issue #74](https://github.com/UnMolDeQuimica/manim-Chemistry/pull/77): Adds error message when trying to run ThreeDMolecules without OpenGL renderer
 
 ### Breaking changes
 * [Issue #48 Fix](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/48): Fix test suite. Removes support for python 3.8 and python 3.9 because configuring the tests on GitHub is trickier.

--- a/src/manim_chemistry/threeD/threedmolecule.py
+++ b/src/manim_chemistry/threeD/threedmolecule.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-from manim import ORIGIN
+from manim import ORIGIN, config
+from manim.constants import RendererType
 from manim.mobject.opengl.opengl_mobject import OpenGLGroup
 
 from ..element import Element
@@ -29,6 +30,8 @@ class ThreeDMolecule(OpenGLGroup, AbstractMolecule):
         *mobjects,
         **kwargs,
     ):
+        if config.renderer != RendererType.OPENGL:
+            raise Exception(f"ThreeDMolecule requires using a OpenGL renderer. You can use it adding the `--renderer=opengl` flag or adding `config.renderer = opengl` to your python file.")
         self.atoms_dict = atoms_dict
         self.bonds_dict = bonds_dict
         self.source_csv = source_csv

--- a/src/manim_chemistry/threeD/threedmolecule.py
+++ b/src/manim_chemistry/threeD/threedmolecule.py
@@ -31,7 +31,9 @@ class ThreeDMolecule(OpenGLGroup, AbstractMolecule):
         **kwargs,
     ):
         if config.renderer != RendererType.OPENGL:
-            raise Exception(f"ThreeDMolecule requires using a OpenGL renderer. You can use it adding the `--renderer=opengl` flag or adding `config.renderer = opengl` to your python file.")
+            raise Exception(
+                "ThreeDMolecule requires using a OpenGL renderer. You can use it adding the `--renderer=opengl` flag or adding `config.renderer = opengl` to your python file."
+            )
         self.atoms_dict = atoms_dict
         self.bonds_dict = bonds_dict
         self.source_csv = source_csv

--- a/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
+++ b/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
@@ -15,6 +15,7 @@ from ..base_test_molecule import BaseTestMolecule
 
 config.renderer = "cairo"
 
+
 class TestGraphMolecule(BaseTestMolecule):
     morphine_file_path = "examples/element_files/morphine.mol"
     molecule_class = GraphMolecule

--- a/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
+++ b/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
@@ -1,3 +1,4 @@
+from manim import config
 import numpy as np
 import pytest
 
@@ -11,6 +12,8 @@ from manim_chemistry.manim_chemistry_molecule import (
 
 from ..base_test_molecule import BaseTestMolecule
 
+
+config.renderer = "cairo"
 
 class TestGraphMolecule(BaseTestMolecule):
     morphine_file_path = "examples/element_files/morphine.mol"

--- a/tests/test_molecules/test_mmolecule/test_mmolecule.py
+++ b/tests/test_molecules/test_mmolecule/test_mmolecule.py
@@ -7,6 +7,7 @@ from ..base_test_molecule import BaseTestMolecule
 
 config.renderer = "cairo"
 
+
 class TestMMolecule(BaseTestMolecule):
     molecule_class = MMoleculeObject
 

--- a/tests/test_molecules/test_mmolecule/test_mmolecule.py
+++ b/tests/test_molecules/test_mmolecule/test_mmolecule.py
@@ -1,11 +1,13 @@
 import pytest
 
+from manim import config
 from manim_chemistry.twoD import MMoleculeObject
 
 from ..base_test_molecule import BaseTestMolecule
 
+config.renderer = "cairo"
 
-class TestThreeDMolecule(BaseTestMolecule):
+class TestMMolecule(BaseTestMolecule):
     molecule_class = MMoleculeObject
 
     @pytest.mark.parametrize("file", BaseTestMolecule.files)

--- a/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
+++ b/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
@@ -1,3 +1,4 @@
+from manim import config
 import pytest
 
 from manim_chemistry.threeD import ThreeDMolecule
@@ -10,25 +11,36 @@ class TestThreeDMolecule(BaseTestMolecule):
 
     @pytest.mark.parametrize("file", BaseTestMolecule.files)
     def test_molecule_from_file(self, file):
+        config.renderer = "opengl"
         molecule = self.molecule_class.molecule_from_file(file)
         assert isinstance(molecule, self.molecule_class)
+        config.renderer = "cairo"
 
     def test_from_pubchem_api_cid(self):
+        config.renderer = "opengl"
         molecule = self.molecule_class.molecule_from_pubchem(cid="2244")
         assert isinstance(molecule, self.molecule_class)
+        config.renderer = "cairo"
 
     def test_from_pubchem_api_name(self):
+        config.renderer = "opengl"
         molecule = self.molecule_class.molecule_from_pubchem(name="aspirin")
         assert isinstance(molecule, self.molecule_class)
+        config.renderer = "cairo"
 
     def test_from_pubchem_api_smiles(self):
+        config.renderer = "opengl"
         molecule = self.molecule_class.molecule_from_pubchem(
             smiles="CC(=O)OC1=CC=CC=C1C(=O)O"
         )
         assert isinstance(molecule, self.molecule_class)
+        config.renderer = "cairo"
 
     def test_from_pubchem_api_inchi(self):
+        config.renderer = "opengl"
         molecule = self.molecule_class.molecule_from_pubchem(
             inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
         )
         assert isinstance(molecule, self.molecule_class)
+        config.renderer = "cairo"
+


### PR DESCRIPTION
# Description

Right now, when using ThreeDMolecule without the OpenGL renderer, it returns an error about the z-index.

This is very annoying and users usually are confused because they do not notice they should use OpenGL renderer.

Adding an error message with a clarification should be enough.

This PR adds the message.

# Related issue

[#74 74 Add error message when using ThreeDMolecule without OpenGL renderer](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/74)

# Pre merge checks

Check the corresponding boxes:

## Tests

- [X] All tests pass.
- [ ] New tests were added.
- [X] New tests were not needed because they are not needed.
- [ ] New tests were not added because I need help.

## Documentation
- [ ] Documentation is up to date with the latest changes.
- [ ] New documentation was not added because it is not needed.
- [ ] New documentation was not added because I need help.

## Linting
- [X] Ruff check passes.
- [X] Ruff format used.

## Changelog
- [X] Changelog has been updated
