### PR TITLE
#80 Make generic class of function for NamedMolecule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 # Documentation
 [Issue #79](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/79): Updates the README.
 
+# New Features
+[Issue #80](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/80): Adds a function to molecules to add the name.
+
 ## 0.5.0
 
 ### Bugfixes

--- a/src/manim_chemistry/molecule/abstract_molecule.py
+++ b/src/manim_chemistry/molecule/abstract_molecule.py
@@ -1,9 +1,11 @@
 from typing import Union, Optional, Tuple, Dict
 from abc import abstractmethod
 
-from manim import VGroup
-from ..utils import PubchemAPIManager
+from manim import VGroup, Text, Tex, DOWN
 from manim.mobject.opengl.opengl_mobject import OpenGLGroup
+import numpy as np
+
+from ..utils import PubchemAPIManager
 from ..manim_chemistry_molecule import MCMolecule
 
 
@@ -214,3 +216,57 @@ class AbstractMolecule:
             Tuple[Dict, Dict]: _description_
         """
         ...
+
+    def add_molecule_name(
+        self,
+        name: Union[Text, Tex, str],
+        direction: np.ndarray = DOWN,
+        buff: float = 0.5,
+        scale: float = 0.75,
+    ):
+        """Adds the name of the molecule.
+
+        Args:
+            name (Union[Text, Tex, str]): Name of the molecule. Can either be a string, a Manim Tex or a Manim Text
+            positdirectionion (np.ndarray, optional): Position where to set the molecule name. Defaults to DOWN.
+            buff (float, optional): Distance between the name and the molecule. Defaults to 0.5.
+            scale (float, optional): Scale of the text. Defaults to 0.75.
+
+        Examples
+        ---------
+
+        .. manim:: MMoleculeWithName
+
+        from manim_chemistry import *
+
+        class MMoleculeWithName(Scene):
+            def construct(self):
+                molecule = MMolecule.molecule_from_file(
+                    "../examples/molecule_files/mol_files/acetone_2d.mol",
+                    ignore_hydrogens=False
+                ).add_molecule_name(name="Acetone")
+                self.wait()
+                self.play(Write(molecule))
+                self.wait()
+
+        .. manim:: GraphMoleculeWithName
+
+        from manim_chemistry import *
+
+        class GraphMoleculeWithName(Scene):
+            def construct(self):
+                molecule = GraphMolecule.molecule_from_file(
+                    "../examples/molecule_files/mol_files/acetone_2d.mol",
+                    ignore_hydrogens=False
+                ).add_molecule_name(name="Acetone")
+                self.wait()
+                self.play(Write(molecule))
+                self.wait()
+
+        """
+
+        if isinstance(name, str):
+            name = Text(name)
+
+        name.scale(scale).next_to(self, direction=direction, buff=buff)
+        self.add(name)

--- a/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
+++ b/tests/test_molecules/test_graph_molecule/test_graph_molecule.py
@@ -91,3 +91,9 @@ class TestGraphMolecule(BaseTestMolecule):
             inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
         )
         assert isinstance(molecule, self.molecule_class)
+
+    def test_add_name_to_molecule(self):
+        molecule = self.molecule_class.molecule_from_file(self.morphine_file_path)
+        molecule.add_molecule_name("morphine")
+
+        assert isinstance(molecule, self.molecule_class)

--- a/tests/test_molecules/test_mmolecule/test_mmolecule.py
+++ b/tests/test_molecules/test_mmolecule/test_mmolecule.py
@@ -9,6 +9,7 @@ config.renderer = "cairo"
 
 
 class TestMMolecule(BaseTestMolecule):
+    morphine_file_path = "examples/molecule_files/mol_files/morphine_2d.mol"
     molecule_class = MMoleculeObject
 
     @pytest.mark.parametrize("file", BaseTestMolecule.files)

--- a/tests/test_molecules/test_mmolecule/test_mmolecule.py
+++ b/tests/test_molecules/test_mmolecule/test_mmolecule.py
@@ -57,3 +57,9 @@ class TestMMolecule(BaseTestMolecule):
             inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
         )
         assert isinstance(molecule, self.molecule_class)
+
+    def test_add_name_to_molecule(self):
+        molecule = self.molecule_class.molecule_from_file(self.morphine_file_path)
+        molecule.add_molecule_name("morphine")
+
+        assert isinstance(molecule, self.molecule_class)

--- a/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
+++ b/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
@@ -7,6 +7,7 @@ from ..base_test_molecule import BaseTestMolecule
 
 
 class TestThreeDMolecule(BaseTestMolecule):
+    morphine_file_path = "examples/molecule_files/mol_files/morphine_2d.mol"
     molecule_class = ThreeDMolecule
 
     @pytest.mark.parametrize("file", BaseTestMolecule.files)
@@ -75,7 +76,10 @@ class TestThreeDMolecule(BaseTestMolecule):
         config.renderer = "cairo"
 
     def test_add_name_to_molecule(self):
+        config.renderer = "opengl"
         molecule = self.molecule_class.molecule_from_file(self.morphine_file_path)
         molecule.add_molecule_name("morphine")
 
         assert isinstance(molecule, self.molecule_class)
+        config.renderer = "cairo"
+        

--- a/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
+++ b/tests/test_molecules/test_threed_molecule/test_three_d_molecule.py
@@ -73,3 +73,9 @@ class TestThreeDMolecule(BaseTestMolecule):
         )
         assert isinstance(molecule, self.molecule_class)
         config.renderer = "cairo"
+
+    def test_add_name_to_molecule(self):
+        molecule = self.molecule_class.molecule_from_file(self.morphine_file_path)
+        molecule.add_molecule_name("morphine")
+
+        assert isinstance(molecule, self.molecule_class)


### PR DESCRIPTION
# Description

Adds a generic function for adding names to molecules. Instead of using the NamedMolecule class, now users should use the function `add_molecule_name`.

# Related issue

[#80 Make generic class of function for NamedMolecule](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/80)

# Pre merge checks

Check the corresponding boxes:

## Tests

- [X] All tests pass.
- [X] New tests were added.
- [ ] New tests were not needed because they are not needed.
- [ ] New tests were not added because I need help.

## Documentation
- [X] Documentation is up to date with the latest changes.
- [ ] New documentation was not added because it is not needed.
- [ ] New documentation was not added because I need help.

## Linting
- [X] Ruff check passes.
- [X] Ruff format used.

## Changelog
- [X] Changelog has been updated
