### PR TITLE
#69 Add Molecule class that works as a proxy for other molecule types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 # Documentation
 [Issue #79](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/79): Updates the README.
 
+# Fix
+[Issue 69](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/69): Fixes an error when calling the PubChem API and returns an error.
+
 ## 0.5.0
 
 ### Bugfixes

--- a/src/manim_chemistry/__init__.py
+++ b/src/manim_chemistry/__init__.py
@@ -5,6 +5,7 @@ from .twoD import *  # noqa F841
 from .orbitals import *  # noqa F841
 from .bohr_atom import *  # noqa F841
 from .utils import *  # noqa F841
+from .molecule import Molecule  # noqa F841
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/src/manim_chemistry/molecule/__init__.py
+++ b/src/manim_chemistry/molecule/__init__.py
@@ -1,1 +1,2 @@
 from .abstract_molecule import AbstractMolecule  # noqa F841
+from .molecule import Molecule  # noqa F841

--- a/src/manim_chemistry/molecule/molecule.py
+++ b/src/manim_chemistry/molecule/molecule.py
@@ -1,0 +1,57 @@
+from ..twoD import GraphMolecule
+
+
+class Molecule:
+    """Works as a proxy between different types of molecules with the same methods.
+
+    Supported types of molecules are:
+        - GraphMolecule
+        - MMoleculeObject
+        - ThreeDMolecule
+
+    Examples
+    ---------
+    .. manim:: GraphMoleculeFromMolecule
+
+        from manim_chemistry import *
+
+        class GraphMoleculeFromMolecule(Scene):
+            def construct(self):
+                molecule = Molecule(GraphMolecule).molecule_from_pubchem(name="acetone")
+                self.wait()
+                self.play(Write(molecule))
+                self.wait()
+
+
+    .. manim:: MMoleculeObjectFromMolecule
+
+        from manim_chemistry import *
+
+        class MMoleculeObjectFromMolecule(Scene):
+            def construct(self):
+                molecule = Molecule(MMoleculeObject).molecule_from_pubchem(name="acetone")
+                self.wait()
+                self.play(Write(molecule))
+                self.wait()
+    """
+
+    def __init__(self, molecule_class=GraphMolecule):
+        self.molecule_class = molecule_class
+
+    def molecule_from_file(self, *args, **kwargs):
+        return self.molecule_class.molecule_from_file(*args, **kwargs)
+
+    def multiple_molecules_from_file(self, *args, **kwargs):
+        return self.molecule_class.multiple_molecules_from_file(*args, **kwargs)
+
+    def molecule_from_string(self, *args, **kwargs):
+        return self.molecule_class.molecule_from_string(*args, **kwargs)
+
+    def multiple_molecules_from_string(self, *args, **kwargs):
+        return self.molecule_class.multiple_molecules_from_string(*args, **kwargs)
+
+    def molecule_from_pubchem(self, *args, **kwargs):
+        return self.molecule_class.molecule_from_pubchem(*args, **kwargs)
+
+    def mc_molecule_to_atoms_and_bonds(self, *args, **kwargs):
+        return self.molecule_class.mc_molecule_to_atoms_and_bonds(*args, **kwargs)

--- a/src/manim_chemistry/utils/pubchem_api.py
+++ b/src/manim_chemistry/utils/pubchem_api.py
@@ -33,7 +33,7 @@ class PubchemAPIManager:
             raise Exception(f"Compound {identifier} not found")
 
         raise Exception(
-            f"An error occurred when calling the Pub Chem API. Status code: {request.status_code}. Request response: {request.response}"
+            f"An error occurred when calling the Pub Chem API. Status code: {request.status_code}. Request response: {request.json}"
         )
 
     def from_cid(self):

--- a/tests/test_molecules/test_molecule/test_molecule.py
+++ b/tests/test_molecules/test_molecule/test_molecule.py
@@ -1,0 +1,221 @@
+from manim import config
+import numpy as np
+import pytest
+
+from manim_chemistry.molecule import Molecule
+from manim_chemistry.twoD import GraphMolecule, MMoleculeObject
+from manim_chemistry.threeD import ThreeDMolecule
+from manim_chemistry.manim_chemistry_molecule import (
+    MCAtom,
+    MCBond,
+    MCElement,
+    MCMolecule,
+)
+
+from ..base_test_molecule import BaseTestMolecule
+
+
+config.renderer = "cairo"
+
+
+class TestMoleculeWithGraphMolecule(BaseTestMolecule):
+    morphine_file_path = "examples/molecule_files/mol_files/morphine_2d.mol"
+    molecule_class = Molecule(molecule_class=GraphMolecule)
+
+    @pytest.fixture
+    def mol_mc_molecule(self):
+        return MCMolecule.construct_from_file(self.morphine_file_path)
+
+    def test_mc_molecule_to_atoms_and_bonds(self, mol_mc_molecule):
+        vertices, edges = Molecule().mc_molecule_to_atoms_and_bonds(mol_mc_molecule)
+
+        assert isinstance(vertices, dict)
+        assert isinstance(edges, dict)
+
+        for index, atom in vertices.items():
+            assert isinstance(index, int)
+            assert isinstance(atom, MCAtom)
+            assert isinstance(atom.element, MCElement)
+            assert isinstance(atom.coords, np.ndarray)
+
+        for index, bond in edges.items():
+            assert isinstance(index, tuple)
+            assert len(index) == 2
+            assert isinstance(index[0], int)
+            assert isinstance(index[1], int)
+            assert isinstance(bond, MCBond)
+            assert isinstance(bond.to_atom, MCAtom)
+            assert isinstance(bond.from_atom, MCAtom)
+
+    @pytest.mark.parametrize("file", BaseTestMolecule.files)
+    def test_molecule_from_file(self, file):
+        molecule = self.molecule_class.molecule_from_file(file)
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_cid(self):
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244")
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_name(self):
+        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin")
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_smiles(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O"
+        )
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_inchi(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+        )
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_cid_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244", three_d=True)
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_name_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            name="aspirin", three_d=True
+        )
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_smiles_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O", three_d=True
+        )
+        assert isinstance(molecule, GraphMolecule)
+
+    def test_from_pubchem_api_inchi_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
+        )
+        assert isinstance(molecule, GraphMolecule)
+
+
+
+
+class TestMoleculeWithMMoleculeObject(BaseTestMolecule):
+    morphine_file_path = "examples/molecule_files/mol_files/morphine_2d.mol"
+    molecule_class = Molecule(molecule_class=MMoleculeObject)
+
+   
+    @pytest.mark.parametrize("file", BaseTestMolecule.files)
+    def test_molecule_from_file(self, file):
+        molecule = self.molecule_class.molecule_from_file(file)
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_cid(self):
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244")
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_name(self):
+        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin")
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_smiles(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O"
+        )
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_inchi(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+        )
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_cid_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244", three_d=True)
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_name_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            name="aspirin", three_d=True
+        )
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_smiles_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O", three_d=True
+        )
+        assert isinstance(molecule, MMoleculeObject)
+
+    def test_from_pubchem_api_inchi_three_d(self):
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
+        )
+        assert isinstance(molecule, MMoleculeObject)
+
+
+class TestMoleculeWithThreeDMolecule(BaseTestMolecule):
+    morphine_file_path = "examples/molecule_files/mol_files/morphine_2d.mol"
+    molecule_class = Molecule(molecule_class=ThreeDMolecule)
+
+   
+    @pytest.mark.parametrize("file", BaseTestMolecule.files)
+    def test_molecule_from_file(self, file):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_file(file)
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_cid(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244")
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_name(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(name="aspirin")
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_smiles(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O"
+        )
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_inchi(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+        )
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_cid_three_d(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(cid="2244", three_d=True)
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_name_three_d(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(
+            name="aspirin", three_d=True
+        )
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_smiles_three_d(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(
+            smiles="CC(=O)OC1=CC=CC=C1C(=O)O", three_d=True
+        )
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"
+
+    def test_from_pubchem_api_inchi_three_d(self):
+        config.renderer = "opengl"
+        molecule = self.molecule_class.molecule_from_pubchem(
+            inchi="BSYNRYMUTXBXSQ-UHFFFAOYSA-N", three_d=True
+        )
+        assert isinstance(molecule, ThreeDMolecule)
+        config.renderer = "cairo"


### PR DESCRIPTION
# Description

Adds class `Molecule` that works as a proxy between multiple molecule types. 

# Related issue

[#69 Add Molecule class that works as a proxy for other molecule types](https://github.com/UnMolDeQuimica/manim-Chemistry/issues/69)

# Pre merge checks

Check the corresponding boxes:

## Tests

- [X] All tests pass.
- [X] New tests were added.
- [ ] New tests were not needed because they are not needed.
- [ ] New tests were not added because I need help.

## Documentation
- [X] Documentation is up to date with the latest changes.
- [ ] New documentation was not added because it is not needed.
- [ ] New documentation was not added because I need help.

## Linting
- [X] Ruff check passes.
- [X] Ruff format used.

## Changelog
- [X] Changelog has been updated
